### PR TITLE
Revamp profile reel and remove engagement

### DIFF
--- a/buddypress-reels.php
+++ b/buddypress-reels.php
@@ -417,12 +417,13 @@ function bpr_profile_feed_shortcode($atts) {
                         </video>
                         
                         <div class="bpr-video-overlay">
-                            <div class="bpr-play-icon">▶</div>
-                            <div class="bpr-pause-icon">⏸</div>
+                            <div class="bpr-controls">
+                                <button class="bpr-mute-toggle" type="button" aria-label="<?php esc_attr_e('Toggle mute', 'buddypress-reels'); ?>">🔇</button>
+                            </div>
                         </div>
                         
-                        <div class="bpr-video-controls">
-                            <button class="bpr-mute-toggle" type="button" aria-label="<?php esc_attr_e('Toggle mute', 'buddypress-reels'); ?>">🔇</button>
+                        <div class="bpr-pause-overlay">
+                            <div class="bpr-pause-icon">⏸️</div>
                         </div>
                     </div>
                     
@@ -720,12 +721,13 @@ function bpr_handle_load_more_profile_reels() {
                 </video>
                 
                 <div class="bpr-video-overlay">
-                    <div class="bpr-play-icon">▶</div>
-                    <div class="bpr-pause-icon">⏸</div>
+                    <div class="bpr-controls">
+                        <button class="bpr-mute-toggle" type="button" aria-label="<?php esc_attr_e('Toggle mute', 'buddypress-reels'); ?>">🔇</button>
+                    </div>
                 </div>
                 
-                <div class="bpr-video-controls">
-                    <button class="bpr-mute-toggle" type="button" aria-label="<?php esc_attr_e('Toggle mute', 'buddypress-reels'); ?>">🔇</button>
+                <div class="bpr-pause-overlay">
+                    <div class="bpr-pause-icon">⏸️</div>
                 </div>
             </div>
             

--- a/css/style.css
+++ b/css/style.css
@@ -190,6 +190,24 @@
     }
 }
 
+@keyframes bpr-temp-icon-animation {
+    0% {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(0.5);
+    }
+    20% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1.2);
+    }
+    40% {
+        transform: translate(-50%, -50%) scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(0.8);
+    }
+}
+
 /* Base Styles */
 * {
     box-sizing: border-box;
@@ -548,20 +566,14 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.4);
-    opacity: 0;
+    background: rgba(0, 0, 0, 0.3);
     transition: var(--bpr-transition-normal);
     pointer-events: none;
     z-index: 10;
     backdrop-filter: var(--bpr-backdrop-blur);
-}
-
-.bpr-pause-overlay.show {
-    opacity: 1;
-    animation: bpr-bounce-in 0.4s ease-out;
 }
 
 .bpr-pause-icon {


### PR DESCRIPTION
Implement Instagram-like video controls for reels, including auto-play muted, click-to-pause/resume, and animated mute/unmute, to enhance user experience.

This PR revamps the video interaction to mimic Instagram Reels, providing a more familiar and engaging experience where videos auto-play muted in the viewport, and users can easily toggle mute/unmute and pause/resume with visual feedback.

---

[Open in Web](https://www.cursor.com/agents?id=bc-9f89f7d6-a01a-4e04-bf2a-27b1b1484ff4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9f89f7d6-a01a-4e04-bf2a-27b1b1484ff4)